### PR TITLE
Test with scoped dbcontext

### DIFF
--- a/src/TplStats.Web/Controllers/SeasonsController.cs
+++ b/src/TplStats.Web/Controllers/SeasonsController.cs
@@ -63,13 +63,18 @@ namespace TplStats.Web.Controllers
         [HttpGet("{id:int}/teams")]
         public async Task<ActionResult<IEnumerable<int>>> ListTeamsAsync(int id, CancellationToken cancellationToken)
         {
-            var season = await Db.Seasons.SingleOrDefaultAsync(s => s.Id == id, cancellationToken: cancellationToken);
-
-            return season switch
+            if (await Db.Seasons.AnyAsync(s => s.Id == id, cancellationToken: cancellationToken))
             {
-                Season s => s.Teams.Select(t => t.Id).ToList(),
-                _ => NotFound(),
-            };
+                return await Db.Seasons
+                    .Where(s => s.Id == id)
+                    .SelectMany(s => s.Teams)
+                    .Select(t => t.Id)
+                    .ToListAsync(cancellationToken: cancellationToken);
+            }
+            else
+            {
+                return NotFound();
+            }
         }
     }
 }

--- a/test/IntegrationTests/Api/Seasons/Id/Teams/GET.cs
+++ b/test/IntegrationTests/Api/Seasons/Id/Teams/GET.cs
@@ -4,6 +4,7 @@ namespace IntegrationTests.Api.Seasons.Id.Teams
     using System.Net;
     using System.Net.Http.Json;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using IntegrationTests.Helpers;
     using TplStats.Core.Entities;
     using Xunit;
@@ -97,7 +98,7 @@ namespace IntegrationTests.Api.Seasons.Id.Teams
             // Assert
             response.EnsureSuccessStatusCode();
             var actual = await response.Content.ReadFromJsonAsync<int[]>(SerializerOptions);
-            Assert.Empty(actual);
+            season.Teams.Select(t => t.Id).Should().BeEquivalentTo(actual);
         }
     }
 }

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/UnitTests/Web/Controllers/Helpers/ControllerTestBase.cs
+++ b/test/UnitTests/Web/Controllers/Helpers/ControllerTestBase.cs
@@ -1,7 +1,10 @@
 namespace UnitTests.Web.Controllers.Helpers
 {
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AutoMapper;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.DependencyInjection;
     using TplStats.Infrastructure.Database;
@@ -12,10 +15,12 @@ namespace UnitTests.Web.Controllers.Helpers
     /// <summary>
     /// Base class for unit testing HTTP API controllers.
     /// </summary>
-    public abstract class ControllerTestBase : XunitContextBase
+    /// <typeparam name="TController">API controller type under test.</typeparam>
+    public abstract class ControllerTestBase<TController> : XunitContextBase
+        where TController : ControllerBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ControllerTestBase"/> class.
+        /// Initializes a new instance of the <see cref="ControllerTestBase{T}"/> class.
         /// </summary>
         /// <param name="testOutputHelper">Test output helper.</param>
         protected ControllerTestBase(ITestOutputHelper testOutputHelper)
@@ -26,22 +31,32 @@ namespace UnitTests.Web.Controllers.Helpers
             {
                 opts.UseInMemoryDatabase(Context.UniqueTestName);
             });
+            services.AddControllers();
             services.AddAutoMapper(typeof(Startup).Assembly);
 
-            Provider = services.BuildServiceProvider();
-            Db = Provider.GetRequiredService<TplStatsContext>();
-            Mapper = Provider.GetRequiredService<IMapper>();
-        }
+            // Add controllers. Bit of a hack, but saves us from having to create separate base classes for each controller type.
+            var controllerTypes = typeof(Startup).Assembly.ExportedTypes
+                .Where(type => type.IsSubclassOf(typeof(ControllerBase)))
+                .ToArray();
+            foreach (var controllerType in controllerTypes)
+            {
+                services.AddScoped(controllerType);
+            }
 
-        /// <summary>
-        /// Gets the database context.
-        /// </summary>
-        protected TplStatsContext Db { get; }
+            Provider = services.BuildServiceProvider();
+            Mapper = Provider.GetRequiredService<IMapper>();
+            Controller = Provider.GetRequiredService<TController>();
+        }
 
         /// <summary>
         /// Gets the mapper.
         /// </summary>
         protected IMapper Mapper { get; }
+
+        /// <summary>
+        /// Gets the HTTP API controller.
+        /// </summary>
+        protected TController Controller { get; }
 
         private ServiceProvider Provider { get; }
 
@@ -51,5 +66,26 @@ namespace UnitTests.Web.Controllers.Helpers
             Provider.Dispose();
             base.Dispose();
         }
+
+        /// <summary>
+        /// Seeds the database with the provided values.
+        /// </summary>
+        /// <param name="entities">The entites to add to the database.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        protected async Task SeedDbAsync(IEnumerable<object> entities)
+        {
+            using var scope = Provider.CreateScope();
+            using var db = scope.ServiceProvider.GetRequiredService<TplStatsContext>();
+
+            db.AddRange(entities);
+            await db.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Seeds the database with the provided values.
+        /// </summary>
+        /// <param name="entities">The entites to add to the database.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        protected Task SeedDbAsync(params object[] entities) => SeedDbAsync(entities.AsEnumerable());
     }
 }

--- a/test/UnitTests/Web/Controllers/SeasonsControllerTests/DetailsAsync.cs
+++ b/test/UnitTests/Web/Controllers/SeasonsControllerTests/DetailsAsync.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
     /// <summary>
     /// Unit tests for <see cref="SeasonsController.DetailsAsync(int, CancellationToken)"/>.
     /// </summary>
-    public class DetailsAsync : ControllerTestBase
+    public class DetailsAsync : ControllerTestBase<SeasonsController>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DetailsAsync"/> class.
@@ -24,10 +24,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
         public DetailsAsync(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)
         {
-            Controller = new(Db, Mapper);
         }
-
-        private SeasonsController Controller { get; }
 
         /// <summary>
         /// Ensures the correct <see cref="Season"/> entity is retrieved.
@@ -40,8 +37,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
             var seasons = Enumerable.Range(1, 10)
                 .Select(x => new Season(x, $"Season #{x}", default, default))
                 .ToList();
-            Db.AddRange(seasons);
-            await Db.SaveChangesAsync();
+            await SeedDbAsync(seasons);
             var season = seasons[5];
 
             // Act
@@ -62,8 +58,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
             var seasons = Enumerable.Range(1, 10)
                 .Select(x => new Season(x, $"Season #{x}", default, default))
                 .ToList();
-            Db.AddRange(seasons);
-            await Db.SaveChangesAsync();
+            await SeedDbAsync(seasons);
             const int id = 42;
 
             // Act

--- a/test/UnitTests/Web/Controllers/SeasonsControllerTests/List.cs
+++ b/test/UnitTests/Web/Controllers/SeasonsControllerTests/List.cs
@@ -13,7 +13,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
     /// <summary>
     /// Unit tests for <see cref="SeasonsController.List"/>.
     /// </summary>
-    public class List : ControllerTestBase
+    public class List : ControllerTestBase<SeasonsController>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List"/> class.
@@ -22,10 +22,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
         public List(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)
         {
-            Controller = new(Db, Mapper);
         }
-
-        private SeasonsController Controller { get; }
 
         /// <summary>
         /// Ensures an empty list is returned when no <see cref="Season"/> entities exist.
@@ -54,8 +51,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
             var seasons = Enumerable.Range(1, 10)
                 .Select(x => new Season(x, $"Season #{x}", default, default))
                 .ToList();
-            Db.AddRange(seasons);
-            await Db.SaveChangesAsync();
+            await SeedDbAsync(seasons);
 
             // Act
             var result = await Controller.List().ToListAsync();

--- a/test/UnitTests/Web/Controllers/SeasonsControllerTests/ListTeamsAsync.cs
+++ b/test/UnitTests/Web/Controllers/SeasonsControllerTests/ListTeamsAsync.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
     /// <summary>
     /// Unit tests for <see cref="SeasonsController.ListTeamsAsync(int, System.Threading.CancellationToken)"/>.
     /// </summary>
-    public class ListTeamsAsync : ControllerTestBase
+    public class ListTeamsAsync : ControllerTestBase<SeasonsController>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ListTeamsAsync"/> class.
@@ -23,10 +23,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
         public ListTeamsAsync(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)
         {
-            Controller = new(Db, Mapper);
         }
-
-        private SeasonsController Controller { get; }
 
         /// <summary>
         /// Ensures the ids for all <see cref="Team"/>s competing in the season are returned.
@@ -40,8 +37,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
             var teams = Enumerable.Range(1, 10)
                 .Select(x => season.AddTeam(x, $"#{x}"))
                 .ToList();
-            Db.Add(season);
-            await Db.SaveChangesAsync();
+            await SeedDbAsync(season);
 
             // Act
             var result = await Controller.ListTeamsAsync(season.Id, default);
@@ -61,8 +57,7 @@ namespace UnitTests.Web.Controllers.SeasonsControllerTests
             var seasons = Enumerable.Range(1, 10)
                 .Select(x => new Season(x, $"Season ${x}", default, default))
                 .ToList();
-            Db.AddRange(seasons);
-            await Db.SaveChangesAsync();
+            await SeedDbAsync(seasons);
             const int id = 42;
 
             // Act

--- a/test/UnitTests/Web/Controllers/TeamsControllerTests/DetailsAsync.cs
+++ b/test/UnitTests/Web/Controllers/TeamsControllerTests/DetailsAsync.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Web.Controllers.TeamsControllerTests
     /// <summary>
     /// Unit tests for <see cref="TeamsController.DetailsAsync(int, CancellationToken)"/>.
     /// </summary>
-    public class DetailsAsync : ControllerTestBase
+    public class DetailsAsync : ControllerTestBase<TeamsController>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DetailsAsync"/> class.
@@ -24,10 +24,7 @@ namespace UnitTests.Web.Controllers.TeamsControllerTests
         public DetailsAsync(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)
         {
-            Controller = new(Db, Mapper);
         }
-
-        private TeamsController Controller { get; }
 
         /// <summary>
         /// Ensures the correct <see cref="Team"/> entity is retrieved.
@@ -41,8 +38,7 @@ namespace UnitTests.Web.Controllers.TeamsControllerTests
             var teams = Enumerable.Range(1, 10)
                 .Select(x => season.AddTeam(x, $"Team #{x}"))
                 .ToList();
-            Db.AddRange(teams);
-            await Db.SaveChangesAsync();
+            await SeedDbAsync(season);
             var team = teams[5];
 
             // Act
@@ -64,8 +60,7 @@ namespace UnitTests.Web.Controllers.TeamsControllerTests
             var teams = Enumerable.Range(1, 10)
                 .Select(x => season.AddTeam(x, $"Team #{x}"))
                 .ToList();
-            Db.AddRange(teams);
-            await Db.SaveChangesAsync();
+            await SeedDbAsync(season);
             const int id = 42;
 
             // Act


### PR DESCRIPTION
Don't re-use database contexts in tests; EF Core caches entities, so re-using means the tests could be passing as a result of the caching in instances where the code under test doesn't properly load data it needs.